### PR TITLE
The Installation fails as connection string is incorrect

### DIFF
--- a/config/db.php.example
+++ b/config/db.php.example
@@ -13,4 +13,5 @@ define("DB_USER", "dcimstack");
 define("DB_PASS", "__PASSWORD_");
 
 // Create connection
-$conn = new mysqli(DB_HOST, DB_HOST, DB_HOST, DB_HOST);
+$conn = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+


### PR DESCRIPTION
http://dcimstack.com/doku.php?id=installing

following the install guide - copies this file over from example to db.php which is formatted incorrectly.
